### PR TITLE
Fix member access precedence and enhance function call parsing

### DIFF
--- a/crates/jsompiler_parser/src/assignment_statement.rs
+++ b/crates/jsompiler_parser/src/assignment_statement.rs
@@ -1,32 +1,55 @@
 use super::{expression::Expression, Parser, Statement};
 use jsompiler_common::{Error, ErrorKind};
-use jsompiler_lexer::symbol::{Lexeme, OperatorToken, Token};
+use jsompiler_lexer::symbol::{OperatorToken, Token};
 
 #[derive(Debug, Clone)]
 pub struct AssignmentStatement {
-    pub token: Lexeme,
-    pub value: Box<Expression>,
+    pub target: Expression,
+    pub value: Expression,
 }
 
 impl Parser {
     pub fn parse_assignment_statement(&mut self) -> Result<Option<Statement>, Vec<Error>> {
-        let identifier = self.peek().clone();
-        self.advance(); // Consume the identifier
+        let target = self.expression()?;
 
-        if !self.match_token(&Token::Operator(OperatorToken::EqualTo)) {
-            return Err(vec![Error {
-                error_kind: ErrorKind::UnexpectedToken,
-                message: "Expected '='".to_string(),
-                line_number: 1,
-                pos: 2,
-            }]);
+        // check for an assignment
+        if self.match_token(&Token::Operator(OperatorToken::EqualTo)) {
+            match &target {
+                Expression::Identifier(_)
+                | Expression::MemberAccess {
+                    object: _,
+                    property: _,
+                } => {
+                    let value = self.expression()?;
+                    return Ok(Some(Statement::AssignmentStatement(AssignmentStatement {
+                        target,
+                        value,
+                    })));
+                }
+                _ => {
+                    return Err(vec![Error {
+                        error_kind: ErrorKind::UnexpectedToken,
+                        message: "Invalid left-hand side in assignment".to_string(),
+                        line_number: 1,
+                        pos: 2,
+                    }]);
+                }
+            }
         }
 
-        let value = Box::new(self.expression()?);
+        // if we don't have an assignment, we can treat it as an expression statement
+        match self.peek().token {
+            Token::Identifier(_) | Token::Literal(_) => {
+                return Err(vec![Error {
+                    error_kind: ErrorKind::UnexpectedToken,
+                    message: "Missing =".to_string(),
+                    line_number: 1,
+                    pos: 2,
+                }]);
+            }
+            _ => {}
+        }
 
-        Ok(Some(Statement::AssignmentStatement(AssignmentStatement {
-            token: identifier,
-            value,
-        })))
+        Ok(Some(Statement::ExpressionStatement(target)))
     }
 }

--- a/crates/jsompiler_parser/src/block_statement.rs
+++ b/crates/jsompiler_parser/src/block_statement.rs
@@ -10,42 +10,34 @@ pub struct BlockStatement {
 
 impl Parser {
     pub fn parse_block_statement(&mut self) -> Result<Option<Statement>, Vec<Error>> {
-        self.advance();
+        self.advance(); // consume '{'
         let mut statements = Vec::new();
-        while !self.is_at_end() {
-            if self.peek().token == Token::Delimiter(DelimiterToken::Semicolon) {
-                self.advance()
-            };
 
-            self.advance();
-            if self.is_at_end() {
-                return Err(vec![Error {
-                    error_kind: ErrorKind::UnexpectedToken,
-                    message: "Expected '}'".to_string(),
-                    line_number: 1,
-                    pos: 2,
-                }]);
-            }
-            let statement = self.parse_statement()?;
-            statements.push(statement);
-            if self.peek().token == Token::EOF {
-                return Err(vec![Error {
-                    error_kind: ErrorKind::UnexpectedToken,
-                    message: "Expected '}'".to_string(),
-                    line_number: 1,
-                    pos: 2,
-                }]);
-            }
-            if self.peek().token == Token::Delimiter(DelimiterToken::Semicolon) {
-                self.advance();
-            }
-            if self.next().token == Token::Delimiter(DelimiterToken::CloseBrace) {
-                println!("Closing block statement");
-                self.advance();
-                self.advance();
-                break;
+        while !self.is_at_end() {
+            match &self.peek().token {
+                Token::Delimiter(DelimiterToken::CloseBrace) => {
+                    self.advance(); // consume '}'
+                    break;
+                }
+                Token::Delimiter(DelimiterToken::Semicolon)
+                | Token::Delimiter(DelimiterToken::NewLine) => {
+                    self.advance();
+                }
+                Token::EOF => {
+                    return Err(vec![Error {
+                        error_kind: ErrorKind::UnexpectedToken,
+                        message: "Expected '}'".to_string(),
+                        line_number: 1,
+                        pos: 2,
+                    }]);
+                }
+                _ => {
+                    let stmt = self.parse_statement()?;
+                    statements.push(stmt);
+                }
             }
         }
+
         Ok(Some(Statement::BlockStatement(BlockStatement {
             token: Token::Delimiter(DelimiterToken::OpenBrace),
             statements,

--- a/crates/jsompiler_parser/src/class_expression.rs
+++ b/crates/jsompiler_parser/src/class_expression.rs
@@ -16,7 +16,7 @@ pub enum ClassElement {
     MethodDefinition {
         name: ClassElementName,
         params: Vec<Identifier>,
-        body: Vec<Statement>,
+        body: Option<Statement>,
         is_static: bool,
     },
     FieldDefinition {
@@ -160,7 +160,7 @@ impl Parser {
         self.advance(); // Consume the name
 
         if self.peek().token == Token::Delimiter(DelimiterToken::OpenParen) {
-            unimplemented!();
+            return self.parse_method(name, is_static);
         } else {
             // Field definition
             let value = if self.peek().token == Token::Operator(OperatorToken::EqualTo) {
@@ -196,5 +196,23 @@ impl Parser {
     fn parse_static_block(&mut self) -> Result<ClassElement, Vec<Error>> {
         let body = self.parse_block_statement()?;
         Ok(ClassElement::StaticBlock { body })
+    }
+
+    fn parse_method(
+        &mut self,
+        name: ClassElementName,
+        is_static: bool,
+    ) -> Result<ClassElement, Vec<Error>> {
+        let params = self.parse_function_parameters()?;
+
+        let body = self.parse_block_statement()?;
+        println!("Parsed method body: {:#?}", body);
+
+        Ok(ClassElement::MethodDefinition {
+            name,
+            params,
+            body,
+            is_static,
+        })
     }
 }

--- a/crates/jsompiler_parser/src/expression.rs
+++ b/crates/jsompiler_parser/src/expression.rs
@@ -26,7 +26,7 @@ pub enum Expression {
         right: Box<Expression>,
     },
     FunctionCall {
-        name: Identifier,
+        callee: Box<Expression>,
         args: Vec<Expression>,
     },
     ArrayLiteral {
@@ -82,9 +82,6 @@ impl Parser {
         if self.peek().token == Token::Keyword(KeywordToken::Class) {
             return self.parse_class_expression();
         }
-        if self.peek().token == Token::Keyword(KeywordToken::This) {
-            return self.parse_this_expression();
-        }
 
         self.comparison() // Start from highest precedence binary operations
     }
@@ -109,9 +106,8 @@ impl Parser {
     }
 
     fn primary(&mut self) -> Result<Expression, Vec<Error>> {
-        if self.match_token(&Token::Delimiter(DelimiterToken::OpenParen)) {
-            let expr = self.expression()?; // Parse inner expression
-
+        let mut expr = if self.match_token(&Token::Delimiter(DelimiterToken::OpenParen)) {
+            let expr = self.expression()?;
             if !self.match_token(&Token::Delimiter(DelimiterToken::CloseParen)) {
                 return Err(vec![Error {
                     error_kind: ErrorKind::UnexpectedToken,
@@ -120,54 +116,49 @@ impl Parser {
                     pos: 2,
                 }]);
             }
-
-            return Ok(expr); // Return the inner expression
-        }
-
-        if let Token::Identifier(_) = self.peek().token {
+            expr
+        } else if let Token::Keyword(KeywordToken::This) = self.peek().token {
+            self.advance(); // Consume 'this'
+            Expression::ThisExpression
+        } else if let Token::Identifier(_) = self.peek().token {
             self.advance();
-
-            // Check if it's a member access
-            if self.peek().token == Token::Delimiter(DelimiterToken::Dot) {
-                return self.parse_member_access(self.previous().clone());
-            }
-
-            // Check if it's a function call
-            if self.peek().token == Token::Delimiter(DelimiterToken::OpenParen) {
-                return self.parse_function_call(self.previous().clone());
-            }
-
-            // Check for postfix increment/decrement
-            if self.match_token(&Token::Operator(OperatorToken::Increment))
-                || self.match_token(&Token::Operator(OperatorToken::Decrement))
-            {
-                return Ok(Expression::Unary {
-                    op: self.previous().clone(),
-                    op_type: "Postfix".to_string(),
-                    expr: Box::new(Expression::Identifier(Identifier {
-                        token: self.previous().clone(),
-                        value: self.previous().text.clone(),
-                    })),
-                });
-            }
-
             let identifier = self.previous().clone();
-            return Ok(Expression::Identifier(Identifier {
+            Expression::Identifier(Identifier {
                 token: identifier.clone(),
                 value: identifier.text.clone(),
-            }));
+            })
+        } else if let Some(literal) = self.match_literal() {
+            Expression::Literal(literal)
+        } else {
+            return Err(vec![Error {
+                error_kind: ErrorKind::UnexpectedToken,
+                message: "Expected expression".to_string(),
+                line_number: 1,
+                pos: 2,
+            }]);
+        };
+
+        // After parsing the primary expression, look for member access or function calls
+        loop {
+            if self.peek().token == Token::Delimiter(DelimiterToken::Dot) {
+                expr = self.parse_member_access(expr)?;
+            } else if self.peek().token == Token::Delimiter(DelimiterToken::OpenParen) {
+                expr = self.parse_function_call(expr)?;
+            } else if self.match_token(&Token::Operator(OperatorToken::Increment))
+                || self.match_token(&Token::Operator(OperatorToken::Decrement))
+            {
+                // Postfix increment/decrement
+                expr = Expression::Unary {
+                    op: self.previous().clone(),
+                    op_type: "Postfix".to_string(),
+                    expr: Box::new(expr),
+                };
+            } else {
+                break; // No more member access or function calls
+            }
         }
 
-        if let Some(literal) = self.match_literal() {
-            return Ok(Expression::Literal(literal));
-        }
-
-        Err(vec![Error {
-            error_kind: ErrorKind::UnexpectedToken,
-            message: "Expected expression".to_string(),
-            line_number: 1,
-            pos: 2,
-        }])
+        Ok(expr)
     }
 
     fn factor(&mut self) -> Result<Expression, Vec<Error>> {
@@ -236,7 +227,7 @@ impl Parser {
         Ok(left)
     }
 
-    fn parse_function_call(&mut self, name: Lexeme) -> Result<Expression, Vec<Error>> {
+    fn parse_function_call(&mut self, callee: Expression) -> Result<Expression, Vec<Error>> {
         println!("Parsing function call");
         self.advance(); // Consume open parenthesis
 
@@ -272,10 +263,7 @@ impl Parser {
         }
 
         Ok(Expression::FunctionCall {
-            name: Identifier {
-                token: name.clone(),
-                value: name.text.clone(),
-            },
+            callee: Box::new(callee),
             args,
         })
     }
@@ -312,54 +300,18 @@ impl Parser {
         Ok(Expression::ArrayLiteral { elements })
     }
 
-    pub fn parse_this_expression(&mut self) -> Result<Expression, Vec<Error>> {
-        if !self.match_token(&Token::Keyword(KeywordToken::This)) {
-            return Err(vec![Error {
-                error_kind: ErrorKind::UnexpectedToken,
-                message: "Expected 'this' keyword".to_string(),
-                line_number: 1,
-                pos: 2,
-            }]);
-        }
-
-        if !self.match_token(&Token::Delimiter(DelimiterToken::Dot)) {
-            return Err(vec![Error {
-                error_kind: ErrorKind::UnexpectedToken,
-                message: "Expected '.' after 'this'".to_string(),
-                line_number: 1,
-                pos: 2,
-            }]);
-        }
-
-        match self.peek().token {
-            Token::Identifier(_) => {
-                let identifier = self.expression()?;
-                Ok(Expression::MemberAccess {
-                    object: Box::new(Expression::ThisExpression),
-                    property: Box::new(identifier),
-                })
-            }
-
-            _ => Err(vec![Error {
-                error_kind: ErrorKind::UnexpectedToken,
-                message: "Expected identifier after 'this.'".to_string(),
-                line_number: 1,
-                pos: 2,
-            }]),
-        }
-    }
-
-    fn parse_member_access(&mut self, object: Lexeme) -> Result<Expression, Vec<Error>> {
+    fn parse_member_access(&mut self, expr: Expression) -> Result<Expression, Vec<Error>> {
         self.advance(); // Consume the dot
 
         if let Token::Identifier(_) = self.peek().token {
-            let property = self.expression()?;
+            self.advance();
+            let property = self.previous().clone();
             Ok(Expression::MemberAccess {
-                object: Box::new(Expression::Identifier(Identifier {
-                    token: object.clone(),
-                    value: object.text.clone(),
+                object: Box::new(expr),
+                property: Box::new(Expression::Identifier(Identifier {
+                    token: property.clone(),
+                    value: property.text.clone(),
                 })),
-                property: Box::new(property),
             })
         } else {
             Err(vec![Error {

--- a/crates/jsompiler_parser/src/function_statement.rs
+++ b/crates/jsompiler_parser/src/function_statement.rs
@@ -36,6 +36,30 @@ impl Parser {
             }]);
         };
 
+        let parameters = self.parse_function_parameters()?;
+
+        // Expect '{' (Start of function body)
+        if !self.match_token(&Token::Delimiter(DelimiterToken::OpenBrace)) {
+            return Err(vec![Error {
+                error_kind: ErrorKind::UnexpectedToken,
+                message: "Expected '{' before function body".to_string(),
+                line_number: 1,
+                pos: 2,
+            }]);
+        }
+
+        // Parse function body (a block statement)
+        let body = self.parse_block_statement()?;
+
+        // Return FunctionStatement node
+        Ok(Some(Statement::FunctionStatement(FunctionStatement {
+            name,
+            parameters,
+            body: Box::new(body),
+        })))
+    }
+
+    pub fn parse_function_parameters(&mut self) -> Result<Vec<Identifier>, Vec<Error>> {
         // Expect '('
         if !self.match_token(&Token::Delimiter(
             jsompiler_lexer::symbol::DelimiterToken::OpenParen,
@@ -72,24 +96,6 @@ impl Parser {
             }]);
         }
 
-        // Expect '{' (Start of function body)
-        if !self.match_token(&Token::Delimiter(DelimiterToken::OpenBrace)) {
-            return Err(vec![Error {
-                error_kind: ErrorKind::UnexpectedToken,
-                message: "Expected '{' before function body".to_string(),
-                line_number: 1,
-                pos: 2,
-            }]);
-        }
-
-        // Parse function body (a block statement)
-        let body = self.parse_block_statement()?;
-
-        // Return FunctionStatement node
-        Ok(Some(Statement::FunctionStatement(FunctionStatement {
-            name,
-            parameters,
-            body: Box::new(body),
-        })))
+        Ok(parameters)
     }
 }

--- a/crates/jsompiler_parser/src/lib.rs
+++ b/crates/jsompiler_parser/src/lib.rs
@@ -103,12 +103,8 @@ impl Parser {
             | Token::Operator(_)
             | Token::Keyword(KeywordToken::Class)
             | Token::Delimiter(DelimiterToken::OpenBracket) => self.parse_expression(),
-            Token::Identifier(_) => {
-                if self.next().token == Token::Operator(OperatorToken::EqualTo) {
-                    self.parse_assignment_statement()
-                } else {
-                    self.parse_expression()
-                }
+            Token::Identifier(_) | Token::Keyword(KeywordToken::This) => {
+                self.parse_assignment_statement()
             }
             Token::ContextualKeyword(ContextualKeywordToken::Let)
             | Token::Keyword(KeywordToken::Var)


### PR DESCRIPTION
Fix member access precedence and improve function call parsing

- Fix precedence issues with the dot operator in expression parsing
- Refactor member access handling to support chained expressions
- Update function call parsing to handle method calls with callee expressions
- Support complex chained expressions like a.b().c()